### PR TITLE
Problem: pub subscription loop gets corrupted when receiving unexpected event

### DIFF
--- a/apps/zmtp/pub.c
+++ b/apps/zmtp/pub.c
@@ -114,9 +114,7 @@ PROCESS_THREAD(zmq_pub_subscription_receiver, ev, data) {
             self->in_conn = list_item_next(self->in_conn);
         }
 
-        PROCESS_WAIT_EVENT();
-        if(data != NULL)
-            self = data;
+        PROCESS_WAIT_EVENT_UNTIL(ev == zmq_socket_input_activity);
 
         self->in_conn = list_head(self->channel.connections);
         msg = NULL;


### PR DESCRIPTION
Eg. a sensors_event when user press a button on the board.
