### PR TITLE
Problem: Multipart msg send too many input activity events

### DIFF
--- a/apps/zmtp/zmtp.c
+++ b/apps/zmtp/zmtp.c
@@ -767,7 +767,8 @@ static int zmtp_tcp_input(struct tcp_socket *s, void *conn_ptr, const uint8_t *i
           pos += read;
           PRINTF("Read a message from wire\r\n");
           zmtp_connection_add_in_msg(conn, msg);
-          process_post(conn->channel->notify_process_input, zmq_socket_input_activity, NULL);
+          if(!(zmq_msg_flags(msg) & ZMQ_MSG_MORE))
+              process_post(conn->channel->notify_process_input, zmq_socket_input_activity, NULL);
       }
   }
 


### PR DESCRIPTION
If the event receiver is doing a recv_multipart on those events, the first event will lead to read all of the parts, and subsequent events will lead to letting recv_multipart calls blocks while there are no data to receive anymore.

Solution: only send the input activity event on msg that do not have the more flag.
